### PR TITLE
Adds `namespace: argocd` to the Kustomize overlay for the self-manage…

### DIFF
--- a/cluster/core/argocd/overlays/default/kustomization.yaml
+++ b/cluster/core/argocd/overlays/default/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Kustomizeで生成されるすべてのリソースに `argocd` 名前空間を適用します
+namespace: argocd
+
 # 上位の `base` ディレクトリを参照します
 resources:
   - ../../base


### PR DESCRIPTION
…d ArgoCD installation.

This resolves the `InvalidSpecError: Namespace for ... is missing` error that occurs when running `kubectl apply -k` without a default namespace specified for the resources. This change ensures all ArgoCD components are correctly installed into the `argocd` namespace.