### PR TITLE
Adds configuration for the MetalLB IP address pool as requested.

### DIFF
--- a/cluster/addons/metallb-config.yaml
+++ b/cluster/addons/metallb-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  # MetalLB本体(wave 0)がデプロイされた後にこの設定(wave 1)が適用されるようにします
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kacchan822/ouchi-k8s
+    path: cluster/core/metallb-config
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    # この設定はmetallb-system名前空間に適用する必要があります
+    namespace: metallb-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      # metallb-system名前空間はmetallbのApplicationが作成するので、ここでは作成しない
+      - CreateNamespace=false

--- a/cluster/core/metallb-config/config.yaml
+++ b/cluster/core/metallb-config/config.yaml
@@ -1,0 +1,18 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.230.64/26
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default-advertisement
+  namespace: metallb-system
+spec:
+  # このアドバタイズメントがどのIPアドレスプールに適用されるかを指定します
+  ipAddressPools:
+  - default-pool


### PR DESCRIPTION
- Creates `IPAddressPool` and `L2Advertisement` custom resources to define the address range `192.168.230.64/26`.
- These resources are placed in `cluster/core/metallb-config/`.
- A new ArgoCD `Application` (`metallb-config`) is created in `cluster/addons/` to manage this configuration.
- A sync-wave of "1" is applied to the configuration application to ensure it's applied after the main MetalLB application (which is implicitly wave "0").